### PR TITLE
routes.rb(修正版）

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   root to: 'posts#index'
   
   post 'posts', to: 'posts#create'
-  # get 'posts/:id', to: 'posts#checked'
+  get 'posts/:id', to: 'posts#checked'
  end


### PR DESCRIPTION
＃what
routes.rb(修正版）
＃why
get 'posts/:id', to: 'posts#checked'を追加するため。